### PR TITLE
Shutdown server when tab is closed

### DIFF
--- a/mdvis/templates/index.html
+++ b/mdvis/templates/index.html
@@ -13,5 +13,12 @@
     <div class="content">
         <iframe src="{{indexpage}}" frameborder="0" class="content-frame" name="content-frame"></iframe>
     </div>
+    <script type="text/javascript">
+        window.onbeforeunload = function () {
+            var xhttp = new XMLHttpRequest();
+            xhttp.open("POST", "close", true);
+            xhttp.send();
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Now it is not needed to go to the terminal and `ctrl`+`c` after ending browsing the folder.

Addresses proposed enhancement: https://github.com/dethos/mdvis/issues/2 
